### PR TITLE
feat: add utf8 and raw+string support

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
 pub mod types;
 use serde_json::Value;
@@ -50,20 +50,35 @@ pub fn dobs_decode(parameters: Parameters) -> Result<Vec<u8>, Error> {
         if spore_dna.len() < byte_offset + byte_length {
             return Err(Error::DecodeInsufficientSporeDNA);
         }
-        let dna_segment = spore_dna[byte_offset..byte_offset + byte_length].to_vec();
+        let mut dna_segment = spore_dna[byte_offset..byte_offset + byte_length].to_vec();
         let offset = match dna_segment.len() {
-            1 => dna_segment[0] as u64,
-            2 => u16::from_le_bytes(dna_segment.try_into().unwrap()) as u64,
-            4 => u32::from_le_bytes(dna_segment.try_into().unwrap()) as u64,
-            8 => u64::from_le_bytes(dna_segment.try_into().unwrap()),
-            _ => return Err(Error::DecodeUnexpectedDNASegment),
+            1 => Some(dna_segment[0] as u64),
+            2 => Some(u16::from_le_bytes(dna_segment.clone().try_into().unwrap()) as u64),
+            4 => Some(u32::from_le_bytes(dna_segment.clone().try_into().unwrap()) as u64),
+            8 => Some(u64::from_le_bytes(dna_segment.clone().try_into().unwrap())),
+            _ => None,
         };
         match schema_base.pattern {
-            Pattern::Raw => {
-                if schema_base.type_ != ArgsType::Number {
+            Pattern::Raw => match schema_base.type_ {
+                ArgsType::Number => {
+                    let value = offset.ok_or(Error::DecodeUnexpectedDNASegment)?;
+                    parsed_dna.traits.push(ParsedTrait::Number(value));
+                }
+                ArgsType::String => {
+                    let value = hex::encode(&dna_segment);
+                    parsed_dna.traits.push(ParsedTrait::String(value));
+                }
+            },
+            Pattern::Utf8 => {
+                if schema_base.type_ != ArgsType::String {
                     return Err(Error::DecodeArgsTypeMismatch);
                 }
-                parsed_dna.traits.push(ParsedTrait::Number(offset));
+                while dna_segment.last() == Some(&0) {
+                    dna_segment.pop();
+                }
+                let value =
+                    String::from_utf8(dna_segment).map_err(|_| Error::DecodeBadUTF8Format)?;
+                parsed_dna.traits.push(ParsedTrait::String(value));
             }
             Pattern::Range => {
                 let args = schema_base.args.ok_or(Error::DecodeMissingRangeArgs)?;
@@ -82,6 +97,7 @@ pub fn dobs_decode(parameters: Parameters) -> Result<Vec<u8>, Error> {
                 if upperbound <= lowerbound {
                     return Err(Error::DecodeInvalidRangeArgs);
                 }
+                let offset = offset.ok_or(Error::DecodeUnexpectedDNASegment)?;
                 let offset = offset % (upperbound - lowerbound);
                 parsed_dna
                     .traits
@@ -92,7 +108,8 @@ pub fn dobs_decode(parameters: Parameters) -> Result<Vec<u8>, Error> {
                 if args.is_empty() {
                     return Err(Error::DecodeInvalidOptionArgs);
                 }
-                let offset = offset as usize % args.len();
+                let offset = offset.ok_or(Error::DecodeUnexpectedDNASegment)? as usize;
+                let offset = offset % args.len();
                 match schema_base.type_ {
                     ArgsType::String => {
                         let value = args[offset].clone();

--- a/src/decoder/types.rs
+++ b/src/decoder/types.rs
@@ -26,6 +26,7 @@ pub enum Error {
     DecodeInvalidRangeArgs,
     DecodeMissingOptionArgs,
     DecodeInvalidOptionArgs,
+    DecodeBadUTF8Format,
 }
 
 #[derive(serde::Serialize)]
@@ -59,6 +60,7 @@ pub enum Pattern {
     Options,
     Range,
     Raw,
+    Utf8,
 }
 
 #[cfg_attr(test, derive(serde::Serialize, Clone))]
@@ -107,6 +109,7 @@ impl TraitSchema {
                 Pattern::Options => "options".to_owned(),
                 Pattern::Range => "range".to_owned(),
                 Pattern::Raw => "raw".to_owned(),
+                Pattern::Utf8 => "utf8".to_owned(),
             }),
         ];
         if let Some(args) = &self.args {
@@ -140,8 +143,9 @@ pub fn decode_trait_schema(traits_pool: Vec<Vec<Value>>) -> Result<Vec<TraitSche
             let pattern_str = schema[4].as_str().ok_or(Error::SchemaInvalidPattern)?;
             let pattern = match (pattern_str, &type_) {
                 ("options", _) => Pattern::Options,
+                ("raw", _) => Pattern::Raw,
+                ("utf8", ArgsType::String) => Pattern::Utf8,
                 ("range", ArgsType::Number) => Pattern::Range,
-                ("raw", ArgsType::Number) => Pattern::Raw,
                 _ => return Err(Error::SchemaPatternMismatch),
             };
             let args = if let Some(args) = schema.get(5) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod test {
 
     #[test]
     fn test_generate_basic_example() {
-        let character_name = TraitSchema::new(
+        let name = TraitSchema::new(
             "Name",
             ArgsType::String,
             0,
@@ -28,7 +28,7 @@ mod test {
                 "Alice", "Bob", "Charlie", "David", "Ethan", "Florence", "Grace", "Helen",
             ]),
         );
-        let character_age = TraitSchema::new(
+        let age = TraitSchema::new(
             "Age",
             ArgsType::Number,
             1,
@@ -36,11 +36,12 @@ mod test {
             Pattern::Range,
             Some(vec!["0", "100"]),
         );
-        let test_score = TraitSchema::new("Score", ArgsType::Number, 2, 1, Pattern::Raw, None);
-        let plain_hex = TraitSchema::new("DNA", ArgsType::String, 3, 3, Pattern::Raw, None);
+        let score = TraitSchema::new("Score", ArgsType::Number, 2, 1, Pattern::Raw, None);
+        let dna = TraitSchema::new("DNA", ArgsType::String, 3, 3, Pattern::Raw, None);
         let url = TraitSchema::new("URL", ArgsType::String, 6, 21, Pattern::Utf8, None);
+        let value = TraitSchema::new("Value", ArgsType::Number, 3, 3, Pattern::Raw, None);
 
-        let schemas = vec![character_name, character_age, test_score, plain_hex, url];
+        let schemas = vec![name, age, score, dna, url, value];
         let traits_base =
             serde_json::to_string(&schemas.iter().map(|v| v.encode()).collect::<Vec<_>>())
                 .expect("stringify traits_base");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,14 +37,16 @@ mod test {
             Some(vec!["0", "100"]),
         );
         let test_score = TraitSchema::new("Score", ArgsType::Number, 2, 1, Pattern::Raw, None);
+        let plain_hex = TraitSchema::new("DNA", ArgsType::String, 3, 3, Pattern::Raw, None);
+        let url = TraitSchema::new("URL", ArgsType::String, 6, 21, Pattern::Utf8, None);
 
-        let schemas = vec![character_name, character_age, test_score];
+        let schemas = vec![character_name, character_age, test_score, plain_hex, url];
         let traits_base =
             serde_json::to_string(&schemas.iter().map(|v| v.encode()).collect::<Vec<_>>())
                 .expect("stringify traits_base");
         println!("trats_base = {traits_base}\n");
 
-        let spore_dna = "ac7b88";
+        let spore_dna = "ac7b88aabbcc687474703a2f2f3132372e302e302e313a38303930";
         let parameters = dobs_parse_parameters(vec![spore_dna.as_bytes(), traits_base.as_bytes()])
             .expect("parse parameters");
 


### PR DESCRIPTION
# Description
for satisfying demands from Nervape team, we introduced two new features, which are:
1. RAW + String: just reverse selected DNA segment back into HEX format
2. UTF8: parse selected DNA segment into plain string